### PR TITLE
Deduplicate and sort YBS outputs

### DIFF
--- a/Ybsnow_Order_Scraper.py
+++ b/Ybsnow_Order_Scraper.py
@@ -215,9 +215,15 @@ class YBSNowScraper:
             if "date" in col or col.endswith("_at"):
                 df[col] = pd.to_datetime(df[col], errors="coerce")
 
+        df = df.drop_duplicates()
+
         return df
 
     def save_outputs(self, df: pd.DataFrame) -> Tuple[str, str, str]:
+        sort_cols = [c for c in ["order_id", "date"] if c in df.columns]
+        if sort_cols:
+            df = df.sort_values(sort_cols).reset_index(drop=True)
+
         df.to_csv(self.cfg.out_csv, index=False)
         df.to_excel(self.cfg.out_xlsx, index=False)
         import sqlite3

--- a/tests/test_output_order.py
+++ b/tests/test_output_order.py
@@ -1,0 +1,47 @@
+import pandas as pd
+import sqlite3
+import sys, pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+from Ybsnow_Order_Scraper import YBSNowScraper, ScrapeConfig
+
+
+def test_save_outputs_preserves_order(tmp_path):
+    df = pd.DataFrame({
+        "order_id": [2, 1, 1, 3],
+        "date": pd.to_datetime([
+            "2024-06-02",
+            "2024-06-01",
+            "2024-06-01",
+            "2024-06-03",
+        ]),
+        "total": [20, 10, 10, 30],
+    })
+
+    cfg = ScrapeConfig(
+        base_url="",
+        login_url="",
+        orders_url="",
+        email="",
+        password="",
+        out_csv=str(tmp_path / "orders.csv"),
+        out_xlsx=str(tmp_path / "orders.xlsx"),
+        out_db=str(tmp_path / "orders.db"),
+    )
+    scraper = YBSNowScraper(cfg)
+
+    cleaned = scraper._clean_df(df)
+    assert len(cleaned) == 3
+    expected = cleaned.sort_values(["order_id", "date"]).reset_index(drop=True)
+
+    csv_path, xlsx_path, db_path = scraper.save_outputs(cleaned)
+
+    df_csv = pd.read_csv(csv_path, parse_dates=["date"])
+    df_xlsx = pd.read_excel(xlsx_path, parse_dates=["date"])
+    conn = sqlite3.connect(db_path)
+    df_sql = pd.read_sql_query("SELECT * FROM orders", conn, parse_dates=["date"])
+    conn.close()
+
+    pd.testing.assert_frame_equal(df_csv, expected, check_dtype=False)
+    pd.testing.assert_frame_equal(df_xlsx, expected, check_dtype=False)
+    pd.testing.assert_frame_equal(df_sql, expected, check_dtype=False)


### PR DESCRIPTION
## Summary
- drop duplicate records in cleaned DataFrames
- sort orders by `order_id` and `date` before writing files
- add regression test verifying sorted output is preserved across CSV, XLSX, and SQLite formats

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d229454ec832dbd1107de383d9c1d