### PR TITLE
Add JSON output option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ Secure Login — Uses the site’s form (email, password, action=signin) to auth
 
 Data Extraction — Grabs the orders table from the authenticated page.
 
-Multiple Outputs — Saves results to .csv, .xlsx, and a user-selected SQLite database.
+Multiple Outputs — Saves results to .csv, .xlsx, .json, and a user-selected SQLite database.
 
 Dual Interface —
 
@@ -57,14 +57,18 @@ Or pass them explicitly:
 python ybsnow_order_scraper.py \
   --orders-url "https://www.ybsnow.com/<orders-page>" \
   --email "you@example.com" \
-  --password "secret"
+  --password "secret" \
+  --out-json "orders.json"
 
+Use `--out-json` to choose the JSON output path (default: `orders.json`).
 
 Output:
 
 orders.csv
 
 orders.xlsx
+
+orders.json
 
 orders.db
 

--- a/tests/test_output_order.py
+++ b/tests/test_output_order.py
@@ -26,6 +26,7 @@ def test_save_outputs_preserves_order(tmp_path):
         password="",
         out_csv=str(tmp_path / "orders.csv"),
         out_xlsx=str(tmp_path / "orders.xlsx"),
+        out_json=str(tmp_path / "orders.json"),
         out_db=str(tmp_path / "orders.db"),
     )
     scraper = YBSNowScraper(cfg)
@@ -34,14 +35,16 @@ def test_save_outputs_preserves_order(tmp_path):
     assert len(cleaned) == 3
     expected = cleaned.sort_values(["order_id", "date"]).reset_index(drop=True)
 
-    csv_path, xlsx_path, db_path = scraper.save_outputs(cleaned)
+    csv_path, xlsx_path, json_path, db_path = scraper.save_outputs(cleaned)
 
     df_csv = pd.read_csv(csv_path, parse_dates=["date"])
     df_xlsx = pd.read_excel(xlsx_path, parse_dates=["date"])
+    df_json = pd.read_json(json_path)
     conn = sqlite3.connect(db_path)
     df_sql = pd.read_sql_query("SELECT * FROM orders", conn, parse_dates=["date"])
     conn.close()
 
     pd.testing.assert_frame_equal(df_csv, expected, check_dtype=False)
     pd.testing.assert_frame_equal(df_xlsx, expected, check_dtype=False)
+    pd.testing.assert_frame_equal(df_json, expected, check_dtype=False)
     pd.testing.assert_frame_equal(df_sql, expected, check_dtype=False)


### PR DESCRIPTION
## Summary
- add `--out-json` flag and `ScrapeConfig.out_json`
- save scraped data to JSON alongside existing formats
- document JSON output option and verify via unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d24da5f64832d867855ce475a4d34