### PR TITLE
Handle numeric header rows in _clean_df

### DIFF
--- a/Ybsnow_Order_Scraper.py
+++ b/Ybsnow_Order_Scraper.py
@@ -177,6 +177,11 @@ class YBSNowScraper:
         import re
         # Normalize column names
         df.columns = [str(c).strip().replace("\n", " ") for c in df.columns]
+        # If columns are numeric indices, the first row contains headers
+        if all(col.isdigit() for col in df.columns):
+            df.columns = df.iloc[0].astype(str).str.strip()
+            df = df[1:].reset_index(drop=True)
+            df.columns = [str(c).strip().replace("\n", " ") for c in df.columns]
         # Drop completely empty columns
         df = df.dropna(axis=1, how="all")
         # Strip whitespace in string cells

--- a/tests/test_output_order.py
+++ b/tests/test_output_order.py
@@ -8,6 +8,7 @@ from Ybsnow_Order_Scraper import (
     YBSNowScraper,
     ScrapeConfig,
     OPTIONAL_COLUMNS,
+    REQUIRED_COLUMNS,
 )
 
 
@@ -77,3 +78,20 @@ def test_clean_df_fills_optional_columns():
     cleaned = scraper._clean_df(df)
     for col in OPTIONAL_COLUMNS:
         assert col in cleaned.columns
+
+
+def test_clean_df_numeric_column_headers():
+    raw = pd.DataFrame([
+        ["Order #", "Date", "Total"],
+        ["1", "2024-06-01", "10"],
+    ])
+    cfg = ScrapeConfig(base_url="", login_url="", orders_url="", email="", password="")
+    scraper = YBSNowScraper(cfg)
+
+    cleaned = scraper._clean_df(raw)
+    expected_cols = REQUIRED_COLUMNS | OPTIONAL_COLUMNS
+    assert set(cleaned.columns) == expected_cols
+    assert len(cleaned) == 1
+    assert cleaned.loc[0, "order_id"] == 1
+    assert cleaned.loc[0, "total"] == 10.0
+    assert cleaned.loc[0, "date"] == pd.Timestamp("2024-06-01")


### PR DESCRIPTION
## Summary
- Detect tables where column names are numeric and use first row as headers
- Expand tests to cover numeric-column tables

## Testing
- `PYTHONWARNINGS=ignore pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d324f994c832d9af9918cdbbb4bc9